### PR TITLE
Added return statement

### DIFF
--- a/src/alepython/ale.py
+++ b/src/alepython/ale.py
@@ -786,3 +786,4 @@ def ale_plot(
             )
         )
     plt.show()
+    return ax


### PR DESCRIPTION
While working on the projects, we generally require the numerical data for the plots to send over the network. The axes object of Matplotlib contains this data. Hence, returning the axes object for the plot.
The data for the first-order-ALE can be accessed through axes.lines and for the second-order-ALE through axes.collections